### PR TITLE
Feature/build api to get allowed provinces

### DIFF
--- a/src/controllers/province.controller.ts
+++ b/src/controllers/province.controller.ts
@@ -1,0 +1,35 @@
+import { Request, Response } from "express";
+import provinceService from "../services/province.service";
+
+export default {
+    getAllowedProvinces: async (req: Request, res: Response) => {
+        const { player_id } = req.params;
+        try {
+            if (!player_id) {
+                res.status(400).json({
+                    message: 'playerId is required'
+                })
+                return;
+            }
+
+            const allowedProvinces = await provinceService.getAllowedProvinces(player_id)
+
+            if (!allowedProvinces) {
+                res.status(404).json({
+                    message: 'Not found'
+                })
+                return;
+            }
+
+            res.status(200).json({
+                message: 'Successfully',
+                data: allowedProvinces,
+            })
+        } catch (error) {
+            res.status(500).json({
+                message: 'Internal Server Error ' + error.message
+            })
+            return;
+        }
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import playerDailyMissionRoute from './routes/playerDailyMission.route';
 import provinceProgressRoute from './routes/provinceProgress.route';
 import leaderboardRoute from './routes/leaderboard.route';
 import playerItemRoute from './routes/playerItem.route';
+import provinceRoute from './routes/province.route';
 
 const app = express();
 app.use(cors());
@@ -20,6 +21,7 @@ app.use('/items', itemRoute);
 app.use('/player-dailymissions', playerDailyMissionRoute);
 app.use('/province-progress', provinceProgressRoute)
 app.use('/leaderboards', leaderboardRoute)
+app.use('/provinces', provinceRoute)
 
 const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {

--- a/src/routes/province.route.ts
+++ b/src/routes/province.route.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import provinceController from '../controllers/province.controller';
+
+const router = express.Router();
+
+router.get('/:player_id/allowed', provinceController.getAllowedProvinces);
+
+export default router;

--- a/src/services/province.service.ts
+++ b/src/services/province.service.ts
@@ -1,0 +1,14 @@
+import db from '../utils/db.util';
+
+export default {
+    getAllowedProvinces: async (player_id: string) => {
+        const allowedProvinces = await db('province')
+            .join('player', 'player.level', '=', 'province.display_order')
+            .where('player.user_id', player_id)
+            .select('province.*');
+
+        if (allowedProvinces.length === 0) return null;
+
+        return allowedProvinces;
+    }
+}

--- a/src/services/province.service.ts
+++ b/src/services/province.service.ts
@@ -2,12 +2,14 @@ import db from '../utils/db.util';
 
 export default {
     getAllowedProvinces: async (player_id: string) => {
-        const allowedProvinces = await db('province')
-            .join('player', 'player.level', '=', 'province.display_order')
-            .where('player.user_id', player_id)
-            .select('province.*');
+        const player = await db('player').where({ user_id: player_id }).first();
+        if (!player) return [];
 
-        if (allowedProvinces.length === 0) return null;
+        const allowedProvinces = await db('province')
+            .where('display_order', '<=', player.level)
+            .select('*');
+
+        if (allowedProvinces.length === 0) return [];
 
         return allowedProvinces;
     }


### PR DESCRIPTION
# [Feature]: Build API to Get Allowed Provinces

## Description
### Briefly describe the purpose of this pull request.
- Developed an API that retrieves the list of provinces a player is allowed to access.
- This feature supports game logic that unlocks new provinces based on player progress.

## Changes
### Outline the main changes made in this pull request.
- **Endpoint:** `GET /:player_id/allowed` — returns all provinces currently accessible by the given player.
- Implemented logic to check province unlock conditions based on progress or achievements.

## Testing
- [x] Local
![image](https://github.com/user-attachments/assets/55dbdbbc-8ba5-49d4-beb2-56c1f85c6e56)
![image](https://github.com/user-attachments/assets/275f694d-be05-40e1-a68f-c9a430b3d383)
![image](https://github.com/user-attachments/assets/3e76f510-a32f-406a-94b2-f5a5e11e3b34)

